### PR TITLE
Fix colors

### DIFF
--- a/Schalterbox/Schalterbox.ino
+++ b/Schalterbox/Schalterbox.ino
@@ -65,7 +65,7 @@ void playMelody();
 void playBeep();
 
 void setup() {
-    Serial.begin(9600);
+    Serial.begin(115200);
     r.begin(true);
 
     for (int i = 0; i < NUM_BUTTONS; i++) {

--- a/Schalterbox/Schalterbox.ino
+++ b/Schalterbox/Schalterbox.ino
@@ -33,7 +33,7 @@ const uint8_t BUTTON_PINS[NUM_BUTTONS] = {ENCODER_PIN_BUTTON, BUTTON_RED_PIN, BU
 // Information about the LED strip itself
 #define NUM_LEDS    12
 #define CHIPSET     WS2801
-#define COLOR_ORDER GRB
+#define COLOR_ORDER RGB
 CRGB leds[NUM_LEDS];
 
 #define BRIGHTNESS  128
@@ -88,7 +88,9 @@ void setup() {
     delay(3000); // power-up safety delay
     // It's important to set the color correction for your LED strip here,
     // so that colors can be more accurately rendered through the 'temperature' profiles
-    FastLED.addLeds<CHIPSET, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection( TypicalSMD5050 );
+    FastLED.addLeds<CHIPSET, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS)
+        .setCorrection( Typical8mmPixel )
+        .setDither(BRIGHTNESS < 255);
     FastLED.setBrightness( BRIGHTNESS );
 }
 
@@ -131,7 +133,7 @@ void loop()
     
     FastLED.show();
     
-    for (int t = 0; t < 25; t++) {
+    for (int t = 0; t < NUM_LEDS; t++) {
         FastLED.delay(ledSpeed);
         bool needToToggleLed = false;
 


### PR DESCRIPTION
The default color order from the examples did not match the actual colors displayed.

Also increased the baud rate to VSCode defaults.